### PR TITLE
RT #97804: Specify license in META

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -49,6 +49,11 @@ my %config = (
             'Test::Pod' => '1.0',
         })
     ),
+
+    ($mm_ver <= 6.31
+        ? ()
+        : (LICENSE => [ 'perl_5' ])
+    ),
     
 );
 


### PR DESCRIPTION
Added version information to Makefile. When creating the dist using "make dist", the META.yml file will be generated with license info, thus fixing RT #97804.
