### PR TITLE
Fix perl version check

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -59,7 +59,7 @@ my %config = (
 );
 
 ## for PPD on win32
-if ($] ge '5.005') {
+if ($] >= 5.005) {
     $config{ AUTHOR   } = 'Andy Wardley <abw@wardley.org>',
     $config{ ABSTRACT } = 'AppConfig is a bundle of Perl5 modules for reading configuration files and parsing command line arguments.';
 }


### PR DESCRIPTION
`$]` is a number and must be compared as a number. A test like `$] ge '5.005'` will start failing once `$]` reaches (or exceeds) 10.0.